### PR TITLE
Add recursive mkdir to create_logfile.

### DIFF
--- a/lib/chrono_logger.rb
+++ b/lib/chrono_logger.rb
@@ -1,5 +1,6 @@
 require "chrono_logger/version"
 require 'logger'
+require 'pathname'
 
 # A lock-free logger with timebased file rotation.
 class ChronoLogger < Logger
@@ -91,6 +92,7 @@ class ChronoLogger < Logger
 
     def create_logfile(filename)
       begin
+        Pathname(filename).dirname.mkpath
         logdev = open(filename, (File::WRONLY | File::APPEND | File::CREAT | File::EXCL))
         logdev.sync = true
       rescue Errno::EEXIST

--- a/test/test_chrono_logger.rb
+++ b/test/test_chrono_logger.rb
@@ -46,6 +46,23 @@ class TestChronoLogger < Test::Unit::TestCase
     end
   end
 
+  def test_rotation_per_day_and_create_dir
+    Dir.mktmpdir do |tmpdir|
+      begin
+        Delorean.time_travel_to '2015-08-01 23:59:50'
+        logger = ChronoLogger.new([tmpdir, '/%Y/%m/%d/test.log'].join)
+        logger.debug 'rotation'
+        Delorean.time_travel_to '2015-08-02 00:00:01'
+        logger.debug 'new dir'
+
+        assert { File.exist?([tmpdir, '/2015/08/01/test.log'].join) }
+        assert { File.exist?([tmpdir, '/2015/08/02/test.log'].join) }
+      ensure
+        Delorean.back_to_the_present
+      end
+    end
+  end
+
   class PeriodTest
     include ChronoLogger::Period
   end


### PR DESCRIPTION
When there was not a directory, I made a recursive directory.

英語が苦手なので日本語で補足させていただくことをお許し下さい。
ログファイルのフォーマット指定時、パスを指定した場合に存在しないディレクトリを作成するようにしました。
chronologからの乗り換えであればこういった使い方もあるかと思いましたので、
お手すきでの際にご確認いただけますと幸いです。
