### PR TITLE
Fix to work with Ruby 2.3

### DIFF
--- a/lib/chrono_logger.rb
+++ b/lib/chrono_logger.rb
@@ -55,7 +55,12 @@ class ChronoLogger < Logger
 
     def initialize(log = nil, opt = {})
       @dev = @filename = nil
-      @mutex = LogDeviceMutex.new
+      if defined?(LogDeviceMutex) # Ruby < 2.3
+        @mutex = LogDeviceMutex.new
+      else
+        mon_initialize
+        @mutex = self
+      end
       if log.respond_to?(:write) and log.respond_to?(:close)
         @dev = log
       else


### PR DESCRIPTION
In ruby 2.3, LogDeviceMutex was removed, and LogDevice itself includes MonitorMixin.
This patch fixes to work with both Ruby 2.3 and Ruby under 2.3. 
