### PR TITLE
fixes fail test in ruby 2.5 by initalize warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ rvm:
   - 2.1.5
   - 2.2.0
   - 2.3.0
+  - 2.4
+  - 2.5
 sudo: false
 cache: bundler

--- a/lib/chrono_logger.rb
+++ b/lib/chrono_logger.rb
@@ -75,7 +75,7 @@ class ChronoLogger < Logger
     end
 
     def write(message)
-      check_and_shift_log if @pattern
+      check_and_shift_log if defined? @pattern
       @dev.write(message)
     rescue
       warn("log writing failed. #{$!}")


### PR DESCRIPTION
I test with ruby 2.5 and it fail by warning message.
The error is following:
```
F
=========================
     84:       logdev.close
     85:       $stderr, stderr = stderr, $stderr
     86:     end
  => 87:     assert_equal "log writing failed. disk is full\n", stderr
     88:   end
     89:
     90:   def test_close
/Users/btm/develop/ruby/chrono_logger/test/from_ruby_repo/test_logdevice.rb:87:in `test_write'
<"log writing failed. disk is full\n"> expected but was
<"/Users/btm/develop/ruby/chrono_logger/lib/chrono_logger.rb:79: warning: instance variable @pattern not initialized\n" +
"log writing failed. disk is full\n">

diff:
+ /Users/btm/develop/ruby/chrono_logger/lib/chrono_logger.rb:79: warning: instance variable @pattern not initialized
  log writing failed. disk is full
Failure: test_write(TestLogDevice)
=========================
```

I fixes it using `defined?` keyword before access `@pattern`.