### PR TITLE
fix the warning message and failed test on ruby 2.6 and 2.7

### DIFF
--- a/lib/chrono_logger.rb
+++ b/lib/chrono_logger.rb
@@ -54,7 +54,7 @@ class ChronoLogger < Logger
     DELAY_SECOND_TO_CLOSE_FILE = 5
 
     def initialize(log = nil, opt = {})
-      @dev = @filename = nil
+      @dev = @filename = @pattern = nil
       if defined?(LogDeviceMutex) # Ruby < 2.3
         @mutex = LogDeviceMutex.new
       else


### PR DESCRIPTION
fix the following warning message to not show

```
warning: instance variable @pattern not initialized
```

closes #5